### PR TITLE
Scala Native Build for 2.11, 2.12 and 2.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,33 +193,33 @@ Before publishing any patch release, binary compatibility with previous version 
     $ sbt ++2.11.12 scalatestShouldMatchersJS/package scalatestShouldMatchersJS/mimaReportBinaryIssues
     $ sbt ++2.11.12 scalatestMustMatchersJS/package scalatestMustMatchersJS/mimaReportBinaryIssues
 
-    $ sbt ++2.12.12 scalactic/package scalactic/mimaReportBinaryIssues
-    $ sbt ++2.12.12 scalatestCore/package scalatestCore/mimaReportBinaryIssues
-    $ sbt ++2.12.12 scalatestFeatureSpec/package scalatestFeatureSpec/mimaReportBinaryIssues
-    $ sbt ++2.12.12 scalatestFlatSpec/package scalatestFlatSpec/mimaReportBinaryIssues
-    $ sbt ++2.12.12 scalatestFreeSpec/package scalatestFreeSpec/mimaReportBinaryIssues
-    $ sbt ++2.12.12 scalatestFunSuite/package scalatestFunSuite/mimaReportBinaryIssues
-    $ sbt ++2.12.12 scalatestFunSpec/package scalatestFunSpec/mimaReportBinaryIssues
-    $ sbt ++2.12.12 scalatestPropSpec/package scalatestPropSpec/mimaReportBinaryIssues
-    $ sbt ++2.12.12 scalatestRefSpec/package scalatestRefSpec/mimaReportBinaryIssues
-    $ sbt ++2.12.12 scalatestWordSpec/package scalatestWordSpec/mimaReportBinaryIssues
-    $ sbt ++2.12.12 scalatestDiagrams/package scalatestDiagrams/mimaReportBinaryIssues
-    $ sbt ++2.12.12 scalatestMatchersCore/package scalatestMatchersCore/mimaReportBinaryIssues
-    $ sbt ++2.12.12 scalatestShouldMatchers/package scalatestShouldMatchers/mimaReportBinaryIssues
-    $ sbt ++2.12.12 scalatestMustMatchers/package scalatestMustMatchers/mimaReportBinaryIssues
-    $ sbt ++2.12.12 scalacticJS/package scalacticJS/mimaReportBinaryIssues
-    $ sbt ++2.12.12 scalatestCoreJS/package scalatestCoreJS/mimaReportBinaryIssues
-    $ sbt ++2.12.12 scalatestFeatureSpecJS/package scalatestFeatureSpecJS/mimaReportBinaryIssues
-    $ sbt ++2.12.12 scalatestFlatSpecJS/package scalatestFlatSpecJS/mimaReportBinaryIssues
-    $ sbt ++2.12.12 scalatestFreeSpecJS/package scalatestFreeSpecJS/mimaReportBinaryIssues
-    $ sbt ++2.12.12 scalatestFunSuiteJS/package scalatestFunSuiteJS/mimaReportBinaryIssues
-    $ sbt ++2.12.12 scalatestFunSpecJS/package scalatestFunSpecJS/mimaReportBinaryIssues
-    $ sbt ++2.12.12 scalatestPropSpecJS/package scalatestPropSpecJS/mimaReportBinaryIssues
-    $ sbt ++2.12.12 scalatestWordSpecJS/package scalatestWordSpecJS/mimaReportBinaryIssues
-    $ sbt ++2.12.12 scalatestDiagramsJS/package scalatestDiagramsJS/mimaReportBinaryIssues
-    $ sbt ++2.12.12 scalatestMatchersCoreJS/package scalatestMatchersCoreJS/mimaReportBinaryIssues
-    $ sbt ++2.12.12 scalatestShouldMatchersJS/package scalatestShouldMatchersJS/mimaReportBinaryIssues
-    $ sbt ++2.12.12 scalatestMustMatchersJS/package scalatestMustMatchersJS/mimaReportBinaryIssues
+    $ sbt ++2.12.13 scalactic/package scalactic/mimaReportBinaryIssues
+    $ sbt ++2.12.13 scalatestCore/package scalatestCore/mimaReportBinaryIssues
+    $ sbt ++2.12.13 scalatestFeatureSpec/package scalatestFeatureSpec/mimaReportBinaryIssues
+    $ sbt ++2.12.13 scalatestFlatSpec/package scalatestFlatSpec/mimaReportBinaryIssues
+    $ sbt ++2.12.13 scalatestFreeSpec/package scalatestFreeSpec/mimaReportBinaryIssues
+    $ sbt ++2.12.13 scalatestFunSuite/package scalatestFunSuite/mimaReportBinaryIssues
+    $ sbt ++2.12.13 scalatestFunSpec/package scalatestFunSpec/mimaReportBinaryIssues
+    $ sbt ++2.12.13 scalatestPropSpec/package scalatestPropSpec/mimaReportBinaryIssues
+    $ sbt ++2.12.13 scalatestRefSpec/package scalatestRefSpec/mimaReportBinaryIssues
+    $ sbt ++2.12.13 scalatestWordSpec/package scalatestWordSpec/mimaReportBinaryIssues
+    $ sbt ++2.12.13 scalatestDiagrams/package scalatestDiagrams/mimaReportBinaryIssues
+    $ sbt ++2.12.13 scalatestMatchersCore/package scalatestMatchersCore/mimaReportBinaryIssues
+    $ sbt ++2.12.13 scalatestShouldMatchers/package scalatestShouldMatchers/mimaReportBinaryIssues
+    $ sbt ++2.12.13 scalatestMustMatchers/package scalatestMustMatchers/mimaReportBinaryIssues
+    $ sbt ++2.12.13 scalacticJS/package scalacticJS/mimaReportBinaryIssues
+    $ sbt ++2.12.13 scalatestCoreJS/package scalatestCoreJS/mimaReportBinaryIssues
+    $ sbt ++2.12.13 scalatestFeatureSpecJS/package scalatestFeatureSpecJS/mimaReportBinaryIssues
+    $ sbt ++2.12.13 scalatestFlatSpecJS/package scalatestFlatSpecJS/mimaReportBinaryIssues
+    $ sbt ++2.12.13 scalatestFreeSpecJS/package scalatestFreeSpecJS/mimaReportBinaryIssues
+    $ sbt ++2.12.13 scalatestFunSuiteJS/package scalatestFunSuiteJS/mimaReportBinaryIssues
+    $ sbt ++2.12.13 scalatestFunSpecJS/package scalatestFunSpecJS/mimaReportBinaryIssues
+    $ sbt ++2.12.13 scalatestPropSpecJS/package scalatestPropSpecJS/mimaReportBinaryIssues
+    $ sbt ++2.12.13 scalatestWordSpecJS/package scalatestWordSpecJS/mimaReportBinaryIssues
+    $ sbt ++2.12.13 scalatestDiagramsJS/package scalatestDiagramsJS/mimaReportBinaryIssues
+    $ sbt ++2.12.13 scalatestMatchersCoreJS/package scalatestMatchersCoreJS/mimaReportBinaryIssues
+    $ sbt ++2.12.13 scalatestShouldMatchersJS/package scalatestShouldMatchersJS/mimaReportBinaryIssues
+    $ sbt ++2.12.13 scalatestMustMatchersJS/package scalatestMustMatchersJS/mimaReportBinaryIssues
 
     $ sbt ++2.13.4 scalactic/package scalactic/mimaReportBinaryIssues
     $ sbt ++2.13.4 scalatestCore/package scalatestCore/mimaReportBinaryIssues

--- a/native/common-test/src/main/scala/org/scalatest/TestConcurrentDistributor.scala
+++ b/native/common-test/src/main/scala/org/scalatest/TestConcurrentDistributor.scala
@@ -18,5 +18,5 @@ class TestConcurrentDistributor extends Distributor {
     status
   }
 
-  def waitUntilDone() = Unit
+  def waitUntilDone() = ()
 }

--- a/project/NativeBuild.scala
+++ b/project/NativeBuild.scala
@@ -21,7 +21,7 @@ trait NativeBuild { this: BuildCommons =>
       // if scala 2.11+ is used, add dependency on scala-xml module
       case Some((2, scalaMajor)) if scalaMajor >= 11 =>
         Seq(
-          "org.scala-lang.modules" %% "scala-xml" % "1.0.6"
+          "org.scala-lang.modules" %% "scala-xml" % "1.3.0"
         )
       case _ =>
         Seq.empty
@@ -259,6 +259,7 @@ trait NativeBuild { this: BuildCommons =>
       projectTitle := "ScalaTest Core Native",
       organization := "org.scalatest",
       moduleName := "scalatest-core",
+      libraryDependencies ++= nativeCrossBuildLibraryDependencies.value,
       libraryDependencies += "org.scala-native" %%% "test-interface" % scalaNativeVersion,
       sourceGenerators in Compile += {
         Def.task {

--- a/publish.sh
+++ b/publish.sh
@@ -6,11 +6,13 @@ sbt "project scalacticJS" clean +publishSigned
 export SCALAJS_VERSION=1.3.0
 sbt "project scalacticMacroJS" clean
 sbt ++2.11.12 "project scalacticJS" clean publishSigned
-sbt ++2.12.12 "project scalacticJS" clean publishSigned
+sbt ++2.12.13 "project scalacticJS" clean publishSigned
 sbt ++2.13.4 "project scalacticJS" clean publishSigned
 export SCALANATIVE_VERSION=0.4.0
 sbt "project scalacticMacroNative" clean
 sbt ++2.11.12 "project scalacticNative" clean publishSigned
+sbt ++2.12.13 "project scalacticNative" clean publishSigned
+sbt ++2.13.4 "project scalacticNative" clean publishSigned
 sbt "project scalacticDotty" clean publishSigned
 sbt "project scalactic" sonatypeBundleUpload
 
@@ -25,11 +27,13 @@ export SCALAJS_VERSION=1.3.0
 sbt "project scalacticMacroJS" clean
 sbt "project scalacticJS" clean
 sbt ++2.11.12 "project scalatestJS" clean publishSigned
-sbt ++2.12.12 "project scalatestJS" clean publishSigned
+sbt ++2.12.13 "project scalatestJS" clean publishSigned
 sbt ++2.13.4 "project scalatestJS" clean publishSigned
 export SCALANATIVE_VERSION=0.4.0
 sbt "project scalacticMacroNative" clean
 sbt ++2.11.12 "project scalatestNative" clean publishSigned
+sbt ++2.12.13 "project scalatestNative" clean publishSigned
+sbt ++2.13.4 "project scalatestNative" clean publishSigned
 sbt "project scalatestDotty" clean publishSigned
 sbt "project scalatest" sonatypeBundleUpload
 
@@ -43,9 +47,11 @@ export SCALAJS_VERSION=1.3.0
 sbt "project scalacticMacroJS" clean
 sbt "project scalacticJS" clean
 sbt ++2.11.12 "project scalatestAppJS" clean publishSigned
-sbt ++2.12.12 "project scalatestAppJS" clean publishSigned
+sbt ++2.12.13 "project scalatestAppJS" clean publishSigned
 sbt ++2.13.4 "project scalatestAppJS" clean publishSigned
 export SCALANATIVE_VERSION=0.4.0
 sbt "project scalacticMacroNative" clean
 sbt ++2.11.12 "project scalatestAppNative" clean publishSigned
+sbt ++2.12.13 "project scalatestAppNative" clean publishSigned
+sbt ++2.13.4 "project scalatestAppNative" clean publishSigned
 sbt "project scalatest" sonatypeBundleUpload


### PR DESCRIPTION
Get native build to work with Scala 2.11.12, 2.12.13 and 2.13.4.

You may try the build with: 

```
sbt ++2.11.12 scalatestTestNative/clean scalacticTestNative/clean commonTestNative/clean scalatestNative/clean scalacticNative/clean scalacticMacroNative/clean
sbt ++2.11.12 scalatestTestNative/test:compile
sbt ++2.11.12 scalatestTestNative/test
sbt ++2.11.12 scalacticTestNative/test:compile
sbt ++2.11.12 scalacticTestNative/test

sbt ++2.12.13 scalatestTestNative/clean scalacticTestNative/clean commonTestNative/clean scalatestNative/clean scalacticNative/clean scalacticMacroNative/clean
sbt ++2.12.13 scalatestTestNative/test:compile
sbt ++2.12.13 scalatestTestNative/test
sbt ++2.12.13 scalacticTestNative/test:compile
sbt ++2.12.13 scalacticTestNative/test

sbt ++2.13.4 scalatestTestNative/clean scalacticTestNative/clean commonTestNative/clean scalatestNative/clean scalacticNative/clean scalacticMacroNative/clean
sbt ++2.13.4 scalatestTestNative/test:compile
sbt ++2.13.4 scalatestTestNative/test
sbt ++2.13.4 scalacticTestNative/test:compile
sbt ++2.13.4 scalacticTestNative/test
```